### PR TITLE
Add padding to missing required fields

### DIFF
--- a/app/services/metadata_mapper.rb
+++ b/app/services/metadata_mapper.rb
@@ -99,7 +99,9 @@ class MetadataMapper
       requirement: :required ,
       item_field: nil
     }
-  }
+  }.freeze
+
+  PADDING = 'NON-COMPLIANT'.freeze
 
   class << self
     def required_fields
@@ -127,7 +129,21 @@ class MetadataMapper
   end
 
   def required_fields_present
-    metadata.slice(*self.class.required_fields).compact.keys
+    @required_fields_present ||= metadata.slice(*self.class.required_fields).compact.keys
+  end
+
+  def required_fields_missing
+    self.class.required_fields - required_fields_present
+  end
+
+  def padded_metadata
+    padding.merge(metadata.compact)
+  end
+
+  private
+
+  def padding
+    required_fields_missing.each_with_object({}) { |field, hash| hash[field] = PADDING }
   end
 end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,10 +29,15 @@
 </pre>
 <h3>Missing required fields</h3>
 <ul>
-  <% (MetadataMapper.required_fields - @metadata_mapper.required_fields_present).each do |missing_field| %>
+  <% @metadata_mapper.required_fields_missing.each do |missing_field| %>
     <li><%= missing_field %></li>
   <% end %>
 </ul>
+
+<h3>Metadata with missing fields padded with dummy data</h3>
+<pre>
+<%= JSON.pretty_generate(@metadata_mapper.padded_metadata) %>
+</pre>
 
 <h2>HTTP endpoint</h2>
 <% if @item.url.present? %>

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe "Items", type: :request do
 
   describe "GET /show" do
     let(:item) { create :item }
+
+    before do
+      stub_request :get, item.url
+    end
+
     it "returns http success" do
       get item_path(item)
       expect(response).to have_http_status(:success)

--- a/spec/services/metadata_mapper_spec.rb
+++ b/spec/services/metadata_mapper_spec.rb
@@ -50,6 +50,41 @@ RSpec.describe MetadataMapper, type: :service do
     it "matches the number of metadata fields that match required fields" do
       expect(metadata_mapper.required_fields_present).to eq(expected)
     end
+
+    context "when required fields are missing" do
+      let(:item) { Item.new }
+
+      it "matches the number of metadata fields that match required fields" do
+        expect(metadata_mapper.required_fields_present).to be_blank
+      end
+    end
   end
 
+  describe 'required_fields_missing' do
+    let(:known_to_be_missing) do
+      [:accessRights, :creator, :identifier, :serviceType, :type, :version]
+    end
+    it "is blank if all required fields are present" do
+      p metadata_mapper.required_fields_missing
+      expect(metadata_mapper.required_fields_missing).to eq(known_to_be_missing)
+    end
+
+    context "when required fields are missing" do
+      let(:item) { Item.new }
+
+      it "matches the number of metadata fields that match required fields" do
+        expect(metadata_mapper.required_fields_missing).to eq(described_class.required_fields)
+      end
+    end
+  end
+
+  describe 'padded_metadata' do
+    it "leaves populated fields" do
+      expect(metadata_mapper.padded_metadata[:contactPoint]).to eq(item.maintainer)
+    end
+
+    it "pads missing fields" do
+      expect(metadata_mapper.padded_metadata[:version]).to eq(described_class::PADDING)
+    end
+  end
 end


### PR DESCRIPTION
One option to allow the API catalogue metadata to be imported into the data marketplace is to pad the missing required fields with text. This update add a representation of what that might look like.